### PR TITLE
Global Setting 154 ("Ins/Outs" => "Return Type"): change from Kind::Flag to Kind::Choice

### DIFF
--- a/crates/fretwire-protocol/src/settings.rs
+++ b/crates/fretwire-protocol/src/settings.rs
@@ -282,10 +282,7 @@ pub const SETTINGS: &[Setting] = &[
         // [XL]
         name: "Return Type",
         group: "Ins/Outs",
-        kind: Kind::Flag {
-            on: "Aux In",
-            off: "Return",
-        },
+        kind: Kind::Choice(&[(0, "Return"), (1, "Aux In")]),
     },
     Setting {
         id: 156,


### PR DESCRIPTION
Follow up to discussion in https://github.com/john-baxter-dev/fretwire/pull/12#issuecomment-5406434308 ; `fretwire-cli` reports a returned type of `int` rather than `bool`

```
cargo run -p fretwire-cli -- setting-get 154

154 = 1  [int]
```