### PR TITLE
Global Settings: populate settings for "Footswitches", "EXP Pedals", "MIDI/Tempo", and "Displays"

### DIFF
--- a/crates/fretwire-protocol/src/settings.rs
+++ b/crates/fretwire-protocol/src/settings.rs
@@ -77,7 +77,7 @@ pub const SETTINGS: &[Setting] = &[
     },
     Setting {
         id: 9,
-        name: "MIDI base channel",
+        name: "MIDI Base Channel",
         group: "MIDI/Tempo",
         // Zero-based on the wire: the pedal's channel 4 reads back as 3. Presented one-based, since
         // that is what the pedal's screen and every other MIDI device call it.
@@ -101,8 +101,9 @@ pub const SETTINGS: &[Setting] = &[
         ]),
     },
     Setting {
-        id: 11,
-        name: "MIDI over USB",
+        id: 10,
+        // [XL]
+        name: "MIDI Thru",
         group: "MIDI/Tempo",
         kind: Kind::Flag {
             on: "On",
@@ -110,14 +111,37 @@ pub const SETTINGS: &[Setting] = &[
         },
     },
     Setting {
-        id: 14,
-        name: "Tempo select",
+        id: 11,
+        name: "USB MIDI",
         group: "MIDI/Tempo",
-        kind: Kind::Choice(&[(0, "Per snapshot"), (1, "Per preset"), (2, "Global")]),
+        kind: Kind::Flag {
+            on: "On",
+            off: "Off",
+        },
+    },
+    Setting {
+        id: 12,
+        // [XL]
+        name: "MIDI PC Rx",
+        group: "MIDI/Tempo",
+        kind: Kind::Choice(&[(0, "Off"), (1, "MIDI"), (2, "USB"), (3, "MIDI+USB")]),
+    },
+    Setting {
+        id: 13,
+        // [XL]
+        name: "Rx MIDI Clock",
+        group: "MIDI/Tempo",
+        kind: Kind::Choice(&[(0, "Off"), (1, "MIDI"), (2, "USB"), (3, "Auto")]),
+    },
+    Setting {
+        id: 14,
+        name: "Tempo Select",
+        group: "MIDI/Tempo",
+        kind: Kind::Choice(&[(0, "Snapsht"), (1, "Preset"), (2, "Global")]),
     },
     Setting {
         id: 16,
-        name: "Tempo",
+        name: "BPM",
         group: "MIDI/Tempo",
         kind: Kind::Number {
             unit: "BPM",
@@ -243,6 +267,20 @@ pub const SETTINGS: &[Setting] = &[
         kind: Kind::Choice(&[(0, "Recall"), (1, "Discard")]),
     },
     Setting {
+        id: 76,
+        // [XL]
+        name: "Tx MIDI Clock",
+        group: "MIDI/Tempo",
+        kind: Kind::Choice(&[(0, "Off"), (1, "MIDI"), (2, "USB"), (3, "MIDI+USB")]),
+    },
+    Setting {
+        id: 77,
+        // [XL]
+        name: "MIDI PC Tx",
+        group: "MIDI/Tempo",
+        kind: Kind::Choice(&[(0, "Off"), (1, "MIDI"), (2, "USB"), (3, "MIDI+USB")]),
+    },
+    Setting {
         id: 81,
         name: "Bypass Type",
         group: "Preferences",
@@ -361,6 +399,13 @@ pub const SETTINGS: &[Setting] = &[
             (8, "AllBypas"),
             (9, "TogglEXP"),
         ]),
+    },
+    Setting {
+        id: 135,
+        // [XL]
+        name: "Snapshot CC Send",
+        group: "MIDI/Tempo",
+        kind: Kind::Choice(&[(0, "Off"), (1, "On")]),
     },
     Setting {
         id: 136,
@@ -521,7 +566,7 @@ pub const MENU_ORDER: &[i64] = &[
     81, 73, 65, 95, 96, 68, 69, 27, 103, 127, 136, // Preferences
     17, 19, 18, 67, 20, 117, 129, 130, 131, // Footswitches
     66, 71, // EXP Pedals
-    9, 11, 14, 16, // MIDI/Tempo
+    9, 10, 13, 76, 14, 16, 11, 12, 77, // MIDI/Tempo
 ];
 
 /// Where `id` sits in the pedal's menus — `MENU_ORDER.len()` for an id nobody has placed.

--- a/crates/fretwire-protocol/src/settings.rs
+++ b/crates/fretwire-protocol/src/settings.rs
@@ -202,6 +202,13 @@ pub const SETTINGS: &[Setting] = &[
         },
     },
     Setting {
+        id: 66,
+        // [XL]
+        name: "EXP 1 Position",
+        group: "EXP Pedals",
+        kind: Kind::Choice(&[(0, "Snapsht"), (1, "Preset"), (2, "Global")]),
+    },
+    Setting {
         id: 67,
         // [XL]
         name: "Snapsht Mode",
@@ -221,6 +228,13 @@ pub const SETTINGS: &[Setting] = &[
         name: "Ring Polarity",
         group: "Preferences",
         kind: Kind::Choice(&[(0, "Normal"), (1, "Inverted")]),
+    },
+    Setting {
+        id: 71,
+        // [XL]
+        name: "EXP 2 Position",
+        group: "EXP Pedals",
+        kind: Kind::Choice(&[(0, "Snapsht"), (1, "Preset"), (2, "Global")]),
     },
     Setting {
         id: 73,
@@ -506,6 +520,7 @@ pub const MENU_ORDER: &[i64] = &[
     31, 94, 2, 3, 154, 153, 158, 156, // Ins/Outs
     81, 73, 65, 95, 96, 68, 69, 27, 103, 127, 136, // Preferences
     17, 19, 18, 67, 20, 117, 129, 130, 131, // Footswitches
+    66, 71, // EXP Pedals
     9, 11, 14, 16, // MIDI/Tempo
 ];
 
@@ -572,11 +587,6 @@ pub fn is_writable(id: i64) -> bool {
 /// menu on the pedal. It leads the list because the panel gives it its own tab, and because every
 /// id in it sorts before the rest anyway; it is here so that [`group_rank`] can place it and so
 /// `every_group_is_declared` keeps covering it.
-///
-/// `EXP Pedals` holds nothing yet. They are declared because the pedal shows both
-/// sections populated, so the ids are there to be found — an empty group is a standing note that
-/// this is where the next `settings-diff` pass should look, and it costs nothing: the panel renders
-/// only groups that have rows.
 pub const GROUPS: &[&str] = &[
     "Global EQ",
     "Ins/Outs",

--- a/crates/fretwire-protocol/src/settings.rs
+++ b/crates/fretwire-protocol/src/settings.rs
@@ -177,6 +177,26 @@ pub const SETTINGS: &[Setting] = &[
         kind: Kind::Choice(&[(0, "Banks"), (1, "Preset"), (2, "Snapsht")]),
     },
     Setting {
+        id: 25,
+        // [XL]
+        name: "LED Rings",
+        group: "Displays",
+        kind: Kind::Flag {
+            on: "Dim/Brt",
+            off: "Off/Brt",
+        },
+    },
+    Setting {
+        id: 26,
+        // [XL]
+        name: "Tap LED",
+        group: "Displays",
+        kind: Kind::Flag {
+            on: "On",
+            off: "Off",
+        },
+    },
+    Setting {
         id: 27,
         // **These labels are the XL's, and they are wrong on a plain Stomp.** The flat form spells
         // out the range, so it differs with the preset count: an HX Stomp shows `000-125` and
@@ -567,6 +587,7 @@ pub const MENU_ORDER: &[i64] = &[
     17, 19, 18, 67, 20, 117, 129, 130, 131, // Footswitches
     66, 71, // EXP Pedals
     9, 10, 13, 76, 14, 16, 11, 12, 77, // MIDI/Tempo
+    25, 26, // Displays
 ];
 
 /// Where `id` sits in the pedal's menus — `MENU_ORDER.len()` for an id nobody has placed.

--- a/crates/fretwire-protocol/src/settings.rs
+++ b/crates/fretwire-protocol/src/settings.rs
@@ -125,6 +125,34 @@ pub const SETTINGS: &[Setting] = &[
         },
     },
     Setting {
+        id: 17,
+        // [XL]
+        name: "Stomp Select",
+        group: "Footswitches",
+        kind: Kind::Choice(&[(0, "Off"), (1, "Touch"), (2, "Press"), (3, "Both")]),
+    },
+    Setting {
+        id: 18,
+        // [XL]
+        name: "Preset Mode",
+        group: "Footswitches",
+        kind: Kind::Choice(&[(0, "Moment"), (1, "Latch")]),
+    },
+    Setting {
+        id: 19,
+        // [XL]
+        name: "Stomp Mode",
+        group: "Footswitches",
+        kind: Kind::Choice(&[(0, "4 Swtch"), (1, "6 Swtch")]),
+    },
+    Setting {
+        id: 20,
+        // [XL]
+        name: "Up/Down Switches",
+        group: "Footswitches",
+        kind: Kind::Choice(&[(0, "Banks"), (1, "Preset"), (2, "Snapsht")]),
+    },
+    Setting {
         id: 27,
         // **These labels are the XL's, and they are wrong on a plain Stomp.** The flat form spells
         // out the range, so it differs with the preset count: an HX Stomp shows `000-125` and
@@ -172,6 +200,13 @@ pub const SETTINGS: &[Setting] = &[
             on: "Transpr",
             off: "Authentc",
         },
+    },
+    Setting {
+        id: 67,
+        // [XL]
+        name: "Snapsht Mode",
+        group: "Footswitches",
+        kind: Kind::Choice(&[(0, "Moment"), (1, "Latch"), (2, "Toggle")]),
     },
     Setting {
         id: 68,
@@ -239,6 +274,13 @@ pub const SETTINGS: &[Setting] = &[
         kind: Kind::Choice(&[(0, "Reload"), (1, "Toggle")]),
     },
     Setting {
+        id: 117,
+        // [XL]
+        name: "Swap Up/Down",
+        group: "Footswitches",
+        kind: Kind::Choice(&[(0, "Off"), (1, "On")]),
+    },
+    Setting {
         id: 127,
         // **Called "Guitar In-Z" here from 2026-08-22 to 2026-08-23, which is not a name this
         // pedal has ever shown.** The pedal said *Auto In-Z*; the write-up supplied a Helix
@@ -259,6 +301,52 @@ pub const SETTINGS: &[Setting] = &[
         name: "Auto In-Z",
         group: "Preferences",
         kind: Kind::Choice(&[(0, "First"), (1, "Enabled")]),
+    },
+    Setting {
+        id: 129,
+        // [XL]
+        name: "TAP Function",
+        group: "Footswitches",
+        kind: Kind::Flag {
+            on: "AllBypas",
+            off: "TAP/Tunr",
+        },
+    },
+    Setting {
+        id: 130,
+        // [XL]
+        name: "FS7 Function",
+        group: "Footswitches",
+        kind: Kind::Choice(&[
+            (0, "TAP/Tunr"),
+            (1, "Stomp 7"),
+            (2, "Bank Up"),
+            (3, "Bank Dn"),
+            (4, "PresetUp"),
+            (5, "PresetDn"),
+            (6, "SnpshtUp"),
+            (7, "SnpshtDn"),
+            (8, "AllBypas"),
+            (9, "TogglEXP"),
+        ]),
+    },
+    Setting {
+        id: 131,
+        // [XL]
+        name: "FS8 Function",
+        group: "Footswitches",
+        kind: Kind::Choice(&[
+            (0, "TAP/Tunr"),
+            (1, "Stomp 8"),
+            (2, "Bank Up"),
+            (3, "Bank Dn"),
+            (4, "PresetUp"),
+            (5, "PresetDn"),
+            (6, "SnpshtUp"),
+            (7, "SnpshtDn"),
+            (8, "AllBypas"),
+            (9, "TogglEXP"),
+        ]),
     },
     Setting {
         id: 136,
@@ -417,6 +505,7 @@ pub const SETTINGS: &[Setting] = &[
 pub const MENU_ORDER: &[i64] = &[
     31, 94, 2, 3, 154, 153, 158, 156, // Ins/Outs
     81, 73, 65, 95, 96, 68, 69, 27, 103, 127, 136, // Preferences
+    17, 19, 18, 67, 20, 117, 129, 130, 131, // Footswitches
     9, 11, 14, 16, // MIDI/Tempo
 ];
 
@@ -484,7 +573,7 @@ pub fn is_writable(id: i64) -> bool {
 /// id in it sorts before the rest anyway; it is here so that [`group_rank`] can place it and so
 /// `every_group_is_declared` keeps covering it.
 ///
-/// `Footswitches` and `EXP Pedals` hold nothing yet. They are declared because the pedal shows both
+/// `EXP Pedals` holds nothing yet. They are declared because the pedal shows both
 /// sections populated, so the ids are there to be found — an empty group is a standing note that
 /// this is where the next `settings-diff` pass should look, and it costs nothing: the panel renders
 /// only groups that have rows.
@@ -623,7 +712,9 @@ mod tests {
     #[test]
     fn groups_rank_in_the_pedals_menu_order() {
         assert!(group_rank("Ins/Outs") < group_rank("Preferences"));
-        assert!(group_rank("Preferences") < group_rank("MIDI/Tempo"));
+        assert!(group_rank("Preferences") < group_rank("Footswitches"));
+        assert!(group_rank("Footswitches") < group_rank("EXP Pedals"));
+        assert!(group_rank("EXP Pedals") < group_rank("MIDI/Tempo"));
         assert!(group_rank("MIDI/Tempo") < group_rank("Displays"));
         // Not a group at all — the raw tier, which must land after every named section.
         assert_eq!(group_rank("Unidentified"), GROUPS.len());


### PR DESCRIPTION
Decoded on an HX Stomp XL using the following procedure:

Setup:

```
cargo run -p fretwire-cli -- settings-dump > base.txt
```

Iterate:

- Change one of the settings
- Run the following commands to see what changed:

```
cargo run -p fretwire-cli -- settings-dump > changed.txt
diff base.txt changed.txt
```

Also, update spellings to match what is shown in the HX Stomp XL Global Settings UI:

- "MIDI base channel" => "MIDI Base Channel"
- "MIDI over USB" => "USB MIDI"
- "Tempo select" => Tempo Select"
- "Tempo" => "BPM"